### PR TITLE
Update rpchdwallet.cpp

### DIFF
--- a/src/wallet/rpchdwallet.cpp
+++ b/src/wallet/rpchdwallet.cpp
@@ -947,7 +947,7 @@ UniValue extkey(const JSONRPCRequest &request)
             };
         }
         if (keyId.IsNull())
-            throw std::runtime_error(strprintf("Must specify ext key or id%s.", mode == "account" ? "or 'default'" : ""));
+            throw std::runtime_error(strprintf("Must specify ext key or id %s.", mode == "account" ? "or 'default'" : ""));
 
         int nListFull = 0; // 0 id only, 1 id+pubkey, 2 id+pubkey+secret
         if (request.params.size() > nParamOffset)


### PR DESCRIPTION
Add space to error message, currently getting "Must specify ext key or idor 'default'."

We should possibly return a different error at this stage, as its throwing an error when mode == "account" and there are no existing wallets.