### PR TITLE
Filtertransactions count

### DIFF
--- a/src/wallet/rpchdwallet.cpp
+++ b/src/wallet/rpchdwallet.cpp
@@ -3112,7 +3112,7 @@ UniValue filtertransactions(const JSONRPCRequest &request)
             "\n"
             "        Expected values are as follows:\n"
             "                count:             number of transactions to be displayed\n"
-            "                                   (integer > 0)\n"
+            "                                   (integer >= 0, use 0 for unlimited)\n"
             "                skip:              number of transactions to skip\n"
             "                                   (integer >= 0)\n"
             "                include_watchonly: whether to include watchOnly transactions\n"
@@ -3182,7 +3182,7 @@ UniValue filtertransactions(const JSONRPCRequest &request)
         );
         if (options.exists("count")) {
             int _count = options["count"].get_int();
-            if (_count < 1) {
+            if (_count < 0) {
                 throw JSONRPCError(RPC_INVALID_PARAMETER,
                     strprintf("Invalid count: %i.", _count));
             }
@@ -3355,8 +3355,11 @@ UniValue filtertransactions(const JSONRPCRequest &request)
     CAmount nTotalAmount = 0, nTotalReward = 0;
     // filter, skip and count
     UniValue result(UniValue::VARR);
+    if (count == 0) {
+        count = values.size();
+    }
     // for every value while count is positive
-    for (unsigned int i = 0; i < values.size() && count > 0; i++) {
+    for (unsigned int i = 0; i < values.size() && count != 0; i++) {
         // if value's category is relevant
         if (values[i]["category"].get_str() == category || category == "all") {
             // if value's type is not relevant

--- a/src/wallet/rpchdwallet.cpp
+++ b/src/wallet/rpchdwallet.cpp
@@ -3169,16 +3169,16 @@ UniValue filtertransactions(const JSONRPCRequest &request)
         const UniValue & options = request.params[0].get_obj();
         RPCTypeCheckObj(options,
             {
-                {"count",               UniValueType(UniValue::VNUM)},
-                {"skip",                UniValueType(UniValue::VNUM)},
-                {"include_watchonly",   UniValueType(UniValue::VBOOL)},
-                {"search",              UniValueType(UniValue::VSTR)},
-                {"category",            UniValueType(UniValue::VSTR)},
-                {"type",                UniValueType(UniValue::VSTR)},
-                {"sort",                UniValueType(UniValue::VSTR)}
+                {"count",             UniValueType(UniValue::VNUM)},
+                {"skip",              UniValueType(UniValue::VNUM)},
+                {"include_watchonly", UniValueType(UniValue::VBOOL)},
+                {"search",            UniValueType(UniValue::VSTR)},
+                {"category",          UniValueType(UniValue::VSTR)},
+                {"type",              UniValueType(UniValue::VSTR)},
+                {"sort",              UniValueType(UniValue::VSTR)}
             },
-            true,             // allow null
-            false             // strict
+            true, // allow null
+            false // strict
         );
         if (options.exists("count")) {
             int _count = options["count"].get_int();
@@ -3296,15 +3296,15 @@ UniValue filtertransactions(const JSONRPCRequest &request)
         int64_t txTime = pwtx->GetTxTime();
         if (txTime < timeFrom) break;
         if (txTime <= timeTo)
-        ParseOutputs(
-            transactions,
-            *pwtx,
-            pwallet,
-            watchonly,
-            search,
-            fWithReward,
-            vDevFundScripts
-        );
+            ParseOutputs(
+                transactions,
+                *pwtx,
+                pwallet,
+                watchonly,
+                search,
+                fWithReward,
+                vDevFundScripts
+            );
         tit++;
     }
 
@@ -3317,28 +3317,28 @@ UniValue filtertransactions(const JSONRPCRequest &request)
         int64_t txTime = rtx.GetTxTime();
         if (txTime < timeFrom) break;
         if (txTime <= timeTo)
-        ParseRecords(
-            transactions,
-            hash,
-            rtx,
-            pwallet,
-            watchonly,
-            search
-        );
+            ParseRecords(
+                transactions,
+                hash,
+                rtx,
+                pwallet,
+                watchonly,
+                search
+            );
         rit++;
     }
 
     // sort
     std::vector<UniValue> values = transactions.getValues();
     std::sort(values.begin(), values.end(), [sort] (UniValue a, UniValue b) -> bool {
-        double a_amount = a["category"].get_str() == "send"
-            ? -(a["amount"].get_real())
-            :   a["amount"].get_real();
-        double b_amount = b["category"].get_str() == "send"
-            ? -(b["amount"].get_real())
-            :   b["amount"].get_real();
         std::string a_address = getAddress(a);
         std::string b_address = getAddress(b);
+        double a_amount =   a["category"].get_str() == "send"
+                        ? -(a["amount"  ].get_real())
+                        :   a["amount"  ].get_real();
+        double b_amount =   b["category"].get_str() == "send"
+                        ? -(b["amount"  ].get_real())
+                        :   b["amount"  ].get_real();
         return (
               sort == "address"
                 ? a_address < b_address
@@ -3352,8 +3352,8 @@ UniValue filtertransactions(const JSONRPCRequest &request)
         );
     });
 
+    // filter, skip, count and sum
     CAmount nTotalAmount = 0, nTotalReward = 0;
-    // filter, skip and count
     UniValue result(UniValue::VARR);
     if (count == 0) {
         count = values.size();

--- a/test/functional/filtertransactions.py
+++ b/test/functional/filtertransactions.py
@@ -167,19 +167,16 @@ class FilterTransactionsTest(ParticlTestFramework):
         # count
         #
 
-        # count: 0 => JSONRPCException
-        try:
-            nodes[0].filtertransactions({ 'count': 0 })
-            assert(False)
-        except JSONRPCException as e:
-            assert('Invalid count' in e.error['message'])
-
         # count: -1 => JSONRPCException
         try:
             nodes[0].filtertransactions({ 'count': -1 })
             assert(False)
         except JSONRPCException as e:
             assert('Invalid count' in e.error['message'])
+
+        # count: 0 => all transactions
+        ro = nodes[0].filtertransactions({ 'count': 0 })
+        assert(len(ro) == 11)
 
         # count: 1
         ro = nodes[0].filtertransactions({ 'count': 1 })

--- a/test/functional/filtertransactions.py
+++ b/test/functional/filtertransactions.py
@@ -142,12 +142,6 @@ class FilterTransactionsTest(ParticlTestFramework):
         self.stakeBlocks(1)
         self.sync_all()
 
-        ro = nodes[0].filtertransactions({'count': 1, 'category': 'send'})
-        assert(len(ro) == 1)
-        ro = nodes[0].filtertransactions({'type': 'blind'})
-        assert(len(ro) == 0)
-
-
         #
         # general
         #


### PR DESCRIPTION
Added the possibility to specify value 0 for param count in order to return all transactions that correspond to the filter, bypassing the default count of 10.