### PR TITLE
Eliminate duplicate source entries in Makefile.am

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -338,11 +338,9 @@ libparticl_wallet_a_SOURCES = \
   wallet/hdwallet.cpp \
   wallet/hdwalletdb.cpp \
   wallet/rpchdwallet.cpp \
-  pos/miner.cpp \
   blind.cpp \
   key/stealth.cpp \
   pos/miner.cpp \
-  pos/kernel.cpp \
   policy/rbf.cpp \
   wallet/walletutil.cpp \
   wallet/coinselection.cpp \


### PR DESCRIPTION
`pos/miner.cpp` is mentioned twice (unnecessarily), `kernel.cpp` is already in server_a