### PR TITLE
rpc(ct): ct fee output & overwrite rangeproof params

### DIFF
--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -293,6 +293,7 @@ public:
     virtual std::vector<uint8_t> *GetPRangeproof() { return nullptr; };
 
     virtual bool GetCTFee(CAmount &nFee) const { return false; };
+    virtual bool SetCTFee(CAmount &nFee) { return false; };
     virtual bool GetDevFundCfwd(CAmount &nCfwd) const { return false; };
 
     std::string ToString() const;
@@ -501,6 +502,13 @@ public:
         size_t nb;
         return (0 == GetVarInt(vData, 1, (uint64_t&)nFee, nb));
     };
+
+    bool SetCTFee(CAmount &nFee) override
+    {
+        vData.clear();
+        vData.push_back(DO_FEE);
+        return (0 == PutVarInt(vData, nFee));
+    }
 
     bool GetDevFundCfwd(CAmount &nCfwd) const override
     {

--- a/src/wallet/hdwallet.cpp
+++ b/src/wallet/hdwallet.cpp
@@ -3079,7 +3079,7 @@ int CHDWallet::AddCTData(CTxOutBase *txout, CTempRecipient &r, std::string &sErr
         return wserrorN(1, sError, __func__, "SelectRangeProofParameters failed.");
     }
 
-    if(r.fOverwriteRangeProofParams == true) {
+    if (r.fOverwriteRangeProofParams == true) {
         min_value = r.min_value;
         ct_exponent = r.ct_exponent;
         ct_bits = r.ct_bits;

--- a/src/wallet/hdwallet.cpp
+++ b/src/wallet/hdwallet.cpp
@@ -3079,6 +3079,12 @@ int CHDWallet::AddCTData(CTxOutBase *txout, CTempRecipient &r, std::string &sErr
         return wserrorN(1, sError, __func__, "SelectRangeProofParameters failed.");
     }
 
+    if(r.fOverwriteRangeProofParams == true) {
+        min_value = r.min_value;
+        ct_exponent = r.ct_exponent;
+        ct_bits = r.ct_bits;
+    }
+
     if (1 != secp256k1_rangeproof_sign(secp256k1_ctx_blind,
         &(*pvRangeproof)[0], &nRangeProofLen,
         min_value, pCommitment,

--- a/src/wallet/hdwallet.h
+++ b/src/wallet/hdwallet.h
@@ -240,6 +240,11 @@ public:
     uint256 nonce;
 
     // TODO: range proof parameters, try to keep similar for fee
+    // Allow an overwrite of the parameters.
+    bool fOverwriteRangeProofParams = false;
+    uint64_t min_value;
+    int ct_exponent;
+    int ct_bits;
 
     CKey sEphem;
     CPubKey pkTo;

--- a/src/wallet/rpchdwallet.cpp
+++ b/src/wallet/rpchdwallet.cpp
@@ -6538,11 +6538,13 @@ static UniValue createrawparttransaction(const JSONRPCRequest& request)
 
         if (o["data_ct_fee"].isStr() || o["data_ct_fee"].isNum())
         {
-            if(nType != OUTPUT_DATA)
+            if (nType != OUTPUT_DATA) {
                 throw JSONRPCError(RPC_INVALID_PARAMETER, "\"data_ct_fee\" can only appear in output of type \"data\".");
+            }
 
-            if (idx != 0)
+            if (idx != 0) {
                 throw JSONRPCError(RPC_INVALID_PARAMETER, "\"data_ct_fee\" can only appear in vout 0.");
+            }
             nCtFee = AmountFromValue(o["data_ct_fee"]);
         };
 
@@ -6596,7 +6598,7 @@ static UniValue createrawparttransaction(const JSONRPCRequest& request)
             {
                 const UniValue &rangeproofParams = o["rangeproof_params"].get_obj();
 
-                if(!rangeproofParams["min_value"].isNum() || !rangeproofParams["ct_exponent"].isNum() || !rangeproofParams["ct_bits"].isNum()) {
+                if (!rangeproofParams["min_value"].isNum() || !rangeproofParams["ct_exponent"].isNum() || !rangeproofParams["ct_bits"].isNum()) {
                     throw JSONRPCError(RPC_INVALID_PARAMETER, "All range proof parameters must be numeric.");
                 }
 

--- a/src/wallet/rpchdwallet.cpp
+++ b/src/wallet/rpchdwallet.cpp
@@ -6366,6 +6366,12 @@ static UniValue createrawparttransaction(const JSONRPCRequest& request)
 //            "         \"subfee\":bool      (boolean, optional, default=false) The fee will be deducted from the amount being sent.\n"
             "         \"narration\" \"str\",        (string, optional) Up to 24 character narration sent with the transaction.\n"
             "         \"blindingfactor\" \"hex\",   (string, optional) Blinding factor to use. Blinding factor is randomly generated if not specified.\n"
+            "         \"rangeproof_params\":  ,     (object, optional) Overwrite the rangeproof parameters of an output \n"
+            "           {\n"
+            "             \"min_value\": x.xxx            (numeric, required) the minimum value to prove for.\n"
+            "             \"ct_exponent\": x              (numeric, required) the exponent to  use.\n"
+            "             \"ct_bits\": x                  (numeric, required) the amount of bits to prove for.\n"
+            "           }\n"
             "         \"ephemeral_key\" \"hex\",    (string, optional) Ephemeral secret key for blinded outputs.\n"
             "         \"nonce\":\"hex\"\n           (string, optional) Nonce for blinded outputs.\n"
             "       }\n"
@@ -6584,6 +6590,20 @@ static UniValue createrawparttransaction(const JSONRPCRequest& request)
             } else {
                 // Generate a random blinding factor if not provided
                 GetStrongRandBytes(r.vBlind.data(), 32);
+            }
+
+            if (o["rangeproof_params"].isObject())
+            {
+                const UniValue &rangeproofParams = o["rangeproof_params"].get_obj();
+
+                if(!rangeproofParams["min_value"].isNum() || !rangeproofParams["ct_exponent"].isNum() || !rangeproofParams["ct_bits"].isNum()) {
+                    throw JSONRPCError(RPC_INVALID_PARAMETER, "All range proof parameters must be numeric.");
+                }
+
+                r.fOverwriteRangeProofParams = true;
+                r.min_value = rangeproofParams["min_value"].get_int64();
+                r.ct_exponent = rangeproofParams["ct_exponent"].get_int();
+                r.ct_bits = rangeproofParams["ct_bits"].get_int();
             }
         }
 


### PR DESCRIPTION
72b8bb5 allows setting a ct fee output using createrawparttransaction
40f22ad  allows an overwrite of the rangeproof parameters