### PR TITLE
Fix werrorN in ExtKeyLoadAccounts

### DIFF
--- a/src/wallet/hdwallet.cpp
+++ b/src/wallet/hdwallet.cpp
@@ -6679,7 +6679,7 @@ int CHDWallet::ExtKeyLoadAccounts()
 
     Dbc *pcursor;
     if (!(pcursor = wdb.GetCursor())) {
-        return werrorN(1, "%s %s: cannot create DB cursor", __func__);
+        return werrorN(1, "%s: cannot create DB cursor", __func__);
     }
 
     CDataStream ssKey(SER_DISK, CLIENT_VERSION);
@@ -6735,7 +6735,7 @@ int CHDWallet::ExtKeyLoadAccounts()
         ExtKeyLoadAccountKeys(&wdb, sea);
 
         if (0 != ExtKeyAddAccountToMaps(idAccount, sea, false)) {
-            WalletLogPrintf("%s: failed: %s\n", __func__, HDAccIDToString(idAccount));
+            WalletLogPrintf("%s: ExtKeyAddAccountToMaps failed: %s\n", __func__, HDAccIDToString(idAccount));
             sea->FreeChains();
             delete sea;
         }


### PR DESCRIPTION
- werrorN has an extra %s . It will cause a fault when if it hits this line.
- WalletLogPrintf is missing the function name "ExtKeyAddAccountToMaps" that failed above.