### PR TITLE
Fix private key display for the liststealthaddresses RPC command

### DIFF
--- a/src/wallet/rpchdwallet.cpp
+++ b/src/wallet/rpchdwallet.cpp
@@ -2110,13 +2110,13 @@ static UniValue liststealthaddresses(const JSONRPCRequest &request)
             objA.pushKV("Address", aks.ToStealthAddress());
 
             if (fShowSecrets) {
-                objA.pushKV("Scan Secret", HexStr(aks.skScan.begin(), aks.skScan.end()));
+                objA.pushKV("Scan Secret", CBitcoinSecret(aks.skScan).ToString());
                 std::string sSpend;
                 CStoredExtKey *sekAccount = ea->ChainAccount();
                 if (sekAccount && !sekAccount->fLocked) {
                     CKey skSpend;
                     if (ea->GetKey(aks.akSpend, skSpend)) {
-                        sSpend = HexStr(skSpend.begin(), skSpend.end());
+                        sSpend = CBitcoinSecret(skSpend).ToString();
                     } else {
                         sSpend = "Extract failed.";
                     }


### PR DESCRIPTION
Changes liststealthaddresses secret key output from hex to base58 format to match the format used for loose stealth addresses (`ListLooseStealthAddresses`):

Before:
![particl-liststealthaddresses-before](https://user-images.githubusercontent.com/13896934/49847926-1c82f180-fd98-11e8-81ad-04be1435b694.png)
After:
![particl-liststealthaddresses-after](https://user-images.githubusercontent.com/13896934/49847929-21e03c00-fd98-11e8-9c7a-743b6a15d408.png)
