### PR TITLE
Fix undefined behavior in CanProvide()

### DIFF
--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -542,7 +542,7 @@ std::unique_ptr<SigningProvider> LegacyScriptPubKeyMan::GetSolvingProvider(const
 
 bool LegacyScriptPubKeyMan::CanProvide(const CScript& script, SignatureData& sigdata)
 {
-    bool isInvalid;
+    bool isInvalid = false;
     isminetype ismine = IsMineInner(*this, script, isInvalid, IsMineSigVersion::TOP, /* recurse_scripthash= */ false);
     if (ismine & ISMINE_ALL) {
         // If ismine, it means we recognize keys or script ids in the script, or


### PR DESCRIPTION
This fix the issue that isInvalid gets a garbage value that in some cases leads to failing functional tests in `functional/wallet_keypool.py` and `functional/wallet_bumpfee.py`